### PR TITLE
Add best-effort support for non-GCP Error Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,15 @@ log entries.
 To use this functionality log messages must be logged in the expected
 [log format][].
 
-*Note*: Currently errors logged from non-GCP instances are not
-ingested into Error Reporting. Please see [issue #4][] for more
-information about this.
+*Note*: Reporting errors from non-GCP instances requires that the
+`LOG_STREAM` environment variable is set to the special value
+`global`.
+
+This value changes the monitored resource descriptor from a log stream
+to the project-global stream. Due to a limitation in Stackdriver Error
+Reporting, this is the only way to correctly ingest errors from
+non-GCP machines. Please see [issue #4][] for more information about
+this.
 
 [Stackdriver Logging]: https://cloud.google.com/logging/
 [metadata server]: https://cloud.google.com/compute/docs/storing-retrieving-metadata

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,9 +160,24 @@ fn get_project_id() -> String {
 /// the metadata server.
 ///
 /// On non-GCP machines the value is determined by using the
-/// `GOOGLE_CLOUD_PROJECT` and `LOG_NAME` environment variables.
+/// `GOOGLE_CLOUD_PROJECT` and `LOG_STREAM` environment variables.
+///
+/// [issue #4]: https://github.com/tazjin/journaldriver/issues/4
 fn determine_monitored_resource() -> Value {
     if let Ok(log) = env::var("LOG_STREAM") {
+        // The special value `global` is recognised as a log stream name that
+        // results in a `global`-type resource descriptor. This is useful in
+        // cases where Stackdriver Error Reporting is intended to be used on
+        // a non-GCE instance. See [issue #4][] for details.
+        if log == "global" {
+            return json!({
+                "type": "global",
+                "labels": {
+                    "project_id": PROJECT_ID.as_str(),
+                }
+            });
+        }
+
         json!({
             "type": "logging_log",
             "labels": {


### PR DESCRIPTION
This adds support for a special log stream name called "global", which
instead of setting that as a log stream changes the resource
descriptor to be of the `global` monitored resource descriptor.

According to the information we have in #4 logs submitted to that
resource descriptor should be compatible with Stackdriver Error
Reporting. This is relevant when running journaldriver outside of GCP
as there is no way to utilise Error Reporting with the log stream
resource.

This relates to #4. I'm unsure about saying whether or not it "fixes"
it.